### PR TITLE
Fix race condition grabbing wrong ColorPicker

### DIFF
--- a/components/Modal.jsx
+++ b/components/Modal.jsx
@@ -122,7 +122,7 @@ module.exports = AsyncComponent.from(
         Header = ModalModule.ModalHeader;
         Content = ModalModule.ModalContent;
         Footer = ModalModule.ModalFooter;
-        ColorPicker = await getModule(m => m.displayName === "ColorPicker");
+        ColorPicker = await getModule(m => m.displayName === "ColorPicker" && m.defaultProps);
         marginBottom20 = (await getModule(["marginBottom20"])).marginBottom20;
 
         resolve(EditNicknameModal);


### PR DESCRIPTION
I suppose I wasn't clear enough, sorry.

This functional component is always loaded and is not the one you want (causes crashes)
![image](https://i.imgur.com/y9cUPiO.png)

However, Powercord fetches the right one by forcing it to load early, once loaded it is the first one returned when searching by displayName, but there's a catch
there is a likely chance that before the component is fully loaded, your plugin will have already started, fetching the wrong component!

It's an easy enough fix though, the right one has an extra prop, or if you wish, it also has `render` in the prototype.